### PR TITLE
Added gitignore for node_modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules


### PR DESCRIPTION
Node_modules can be downloaded with npm install using the package.json file and there's no need to push it to github when you can just do the npm install. It won't work on some devices because node can have a different version on those devices as well :)